### PR TITLE
Fix for pasted text

### DIFF
--- a/TwoWayBondage/Classes/Bindable.swift
+++ b/TwoWayBondage/Classes/Bindable.swift
@@ -54,7 +54,9 @@ extension Bindable where Self: NSObject {
 
     public func bind(with observable: Observable<BindingType>) {
         if let _self = self as? UIControl {
-            _self.addTarget(Selector, action: Selector{ self.valueChanged() }, for: [.editingChanged, .valueChanged])
+            _self.addTarget(Selector,
+                            action: Selector{ self.valueChanged() },
+                            for: [.editingChanged, .valueChanged, .editingDidEnd])
         }
         self.binder = observable
         if let val = observable.value {


### PR DESCRIPTION
The issue was - when UITextField is binded to an observable and a text is pasted to the binded text field, the value of the observable is not being changed with the updated value. Fixed it with adding .editingDidEnd to the events that are being listened for